### PR TITLE
feat(llm): LocalAI provider (HTTP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DevOps Autopilot
 
 ![CI](https://github.com/dajoen/devops-autopilot/actions/workflows/ci.yml/badge.svg)
-![Python](https://img.shields.io/badge/python-3.12-blue)
+![Python](https://img.shields.io/badge/python-3.13-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 A Python 3.12 FastAPI application for automated DevOps operations with PostgreSQL and InfluxDB integration.
@@ -89,7 +89,7 @@ Browse:
 
 ## Full setup (Local)
 
-Recommended Python: 3.12 (or use the Dev Container below).
+Recommended Python: 3.13 (or use the Dev Container below).
 
 ```bash
 python3.12 -m venv venv
@@ -104,7 +104,7 @@ Ensure your Postgres and InfluxDB are available, or use the Dev Container which 
 
 This repository includes a VS Code Dev Container for consistent development:
 
-- Services: Python 3.12 app container, Postgres 16, InfluxDB 2.7
+- Services: Python 3.13 app container, Postgres 16, InfluxDB 2.7
 - Auto-forwards: 8000 (API), 5432 (Postgres), 8086 (InfluxDB)
 
 How to use:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Browse:
 Recommended Python: 3.13 (or use the Dev Container below).
 
 ```bash
-python3.12 -m venv venv
+python3.13 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 uvicorn main:app --host 0.0.0.0 --port 8000 --reload

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Python](https://img.shields.io/badge/python-3.13-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-A Python 3.12 FastAPI application for automated DevOps operations with PostgreSQL and InfluxDB integration.
+A Python 3.13 FastAPI application for automated DevOps operations with PostgreSQL and InfluxDB integration.
 
 ## Features
 

--- a/backend/services/llm/provider.py
+++ b/backend/services/llm/provider.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Type, Callable
 
 from ...core.settings import Settings
+import httpx
 
 
 class LLMProvider(ABC):
@@ -73,4 +74,73 @@ __all__ = [
     "LLMProvider",
     "DummyProvider",
     "register_provider",
+    "LocalAIProvider",
 ]
+
+
+# --- LocalAI implementation ---
+class LocalAIProvider(LLMProvider):
+    name = "localai"
+
+    def __init__(self, base_url: str, model: str, temperature: float | None = None, max_tokens: int | None = None,
+                 requester: Callable[..., Any] | None = None):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        # Dependency injection for unit tests
+        self._requester = requester or _httpx_post
+
+    def complete(self, prompt: str, **params: Any) -> str:
+        payload = {
+            "model": params.get("model", self.model),
+            "prompt": prompt,
+            "temperature": params.get("temperature", self.temperature),
+            "max_tokens": params.get("max_tokens", self.max_tokens),
+            "stream": False,
+        }
+        # Clean None values
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        url = f"{self.base_url}/v1/completions"
+        resp = self._requester(url, json=payload, timeout=30)
+        if resp.status_code >= 400:
+            body = _safe_snippet(resp)
+            raise RuntimeError(f"LocalAI error {resp.status_code} at /v1/completions: {body}")
+        data = resp.json()
+        # Expected format: { choices: [ { text: "..." } ] }
+        try:
+            return data["choices"][0]["text"]
+        except Exception as e:
+            raise ValueError(f"Unexpected LocalAI response format: {data}") from e
+
+
+def _httpx_post(url: str, **kwargs: Any) -> Any:
+    return httpx.post(url, **kwargs)
+
+
+def _safe_snippet(resp: Any, limit: int = 300) -> str:
+    try:
+        txt = resp.text
+    except Exception:
+        return "<no body>"
+    return (txt[:limit] + ("…" if len(txt) > limit else ""))
+
+
+@register_provider("localai")
+def _build_localai(settings: Settings) -> LLMProvider:
+    cfg = settings._config  # type: ignore[attr-defined]
+    llm = cfg.external_apis.llm if cfg.external_apis else None
+    if not llm or not llm.base_url:
+        raise ValueError("LocalAI requires external_apis.llm.base_url or LLM_BASE_URL env var")
+    model = llm.model or "gpt-3.5-turbo"
+    # Temperature and max_tokens are optional; not present in config yet.
+    temperature = None
+    max_tokens = None
+    return LocalAIProvider(
+        base_url=str(llm.base_url),
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )
+

--- a/tests/test_localai_provider.py
+++ b/tests/test_localai_provider.py
@@ -1,0 +1,52 @@
+import json
+from typing import Any, Dict
+
+import pytest
+
+from backend.services.llm.provider import LocalAIProvider
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: Dict[str, Any] | None = None, text: str = ""):
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = text or json.dumps(self._body)
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+
+def test_localai_success_returns_text():
+    sent: Dict[str, Any] = {}
+
+    def requester(url: str, **kwargs: Any):
+        sent.update({"url": url, "kwargs": kwargs})
+        return _FakeResponse(200, {"choices": [{"text": "hello world"}]})
+
+    p = LocalAIProvider(base_url="http://localhost:8080", model="foo", requester=requester)
+    out = p.complete("hi there", max_tokens=10)
+    assert out == "hello world"
+    assert sent["url"].endswith("/v1/completions")
+    payload = sent["kwargs"]["json"]
+    assert payload["prompt"] == "hi there"
+    assert payload["model"] == "foo"
+    assert payload["max_tokens"] == 10
+
+
+def test_localai_http_error_raises():
+    def requester(url: str, **kwargs: Any):
+        return _FakeResponse(500, text="internal error")
+
+    p = LocalAIProvider(base_url="http://localhost:8080", model="foo", requester=requester)
+    with pytest.raises(RuntimeError) as e:
+        p.complete("boom")
+    assert "/v1/completions" in str(e.value)
+
+
+def test_localai_bad_format_raises():
+    def requester(url: str, **kwargs: Any):
+        return _FakeResponse(200, {"unexpected": True})
+
+    p = LocalAIProvider(base_url="http://localhost:8080", model="foo", requester=requester)
+    with pytest.raises(ValueError):
+        p.complete("test")


### PR DESCRIPTION
Implements LocalAIProvider with httpx and unit tests.\n\n- Non-streaming /v1/completions endpoint\n- Injectable requester for tests\n- Error handling for HTTP status and unexpected response\n- Lightweight imports for services/models to keep tests fast\n\nCloses #6.